### PR TITLE
Upgraded to Node v0.12.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,5 +16,9 @@
     "type": "git",
     "url": "git://github.com/jinder/path.git"
   },
-  "main": "./path.js"
+  "main": "./path.js",
+  "dependencies": {
+    "process": "^0.11.1",
+    "util": "^0.10.3"
+  }
 }

--- a/path.js
+++ b/path.js
@@ -1,7 +1,3 @@
-var process = process || {};
-(function () {
-  "use strict";
-
 // Copyright Joyent, Inc. and other Node contributors.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
@@ -23,431 +19,318 @@ var process = process || {};
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+'use strict';
+
 
 var isWindows = process.platform === 'win32';
 var util = require('util');
 
 
 // resolves . and .. elements in a path array with directory names there
-// must be no slashes, empty elements, or device names (c:\) in the array
+// must be no slashes or device names (c:\) in the array
 // (so also no leading and trailing slashes - it does not distinguish
 // relative and absolute paths)
 function normalizeArray(parts, allowAboveRoot) {
-  // if the path tries to go above the root, `up` ends up > 0
-  var up = 0;
-  for (var i = parts.length - 1; i >= 0; i--) {
-    var last = parts[i];
-    if (last === '.') {
-      parts.splice(i, 1);
-    } else if (last === '..') {
-      parts.splice(i, 1);
-      up++;
-    } else if (up) {
-      parts.splice(i, 1);
-      up--;
+  var res = [];
+  for (var i = 0; i < parts.length; i++) {
+    var p = parts[i];
+
+    // ignore empty parts
+    if (!p || p === '.')
+      continue;
+
+    if (p === '..') {
+      if (res.length && res[res.length - 1] !== '..') {
+        res.pop();
+      } else if (allowAboveRoot) {
+        res.push('..');
+      }
+    } else {
+      res.push(p);
     }
   }
 
-  // if the path is allowed to go above the root, restore leading ..s
-  if (allowAboveRoot) {
-    for (; up--; up) {
-      parts.unshift('..');
+  return res;
+}
+
+// returns an array with empty elements removed from either end of the input
+// array or the original array if no elements need to be removed
+function trimArray(arr) {
+  var lastIndex = arr.length - 1;
+  var start = 0;
+  for (; start <= lastIndex; start++) {
+    if (arr[start])
+      break;
+  }
+
+  var end = lastIndex;
+  for (; end >= 0; end--) {
+    if (arr[end])
+      break;
+  }
+
+  if (start === 0 && end === lastIndex)
+    return arr;
+  if (start > end)
+    return [];
+  return arr.slice(start, end + 1);
+}
+
+// Regex to split a windows path into three parts: [*, device, slash,
+// tail] windows-only
+var splitDeviceRe =
+    /^([a-zA-Z]:|[\\\/]{2}[^\\\/]+[\\\/]+[^\\\/]+)?([\\\/])?([\s\S]*?)$/;
+
+// Regex to split the tail part of the above into [*, dir, basename, ext]
+var splitTailRe =
+    /^([\s\S]*?)((?:\.{1,2}|[^\\\/]+?|)(\.[^.\/\\]*|))(?:[\\\/]*)$/;
+
+var win32 = {};
+
+// Function to split a filename into [root, dir, basename, ext]
+function win32SplitPath(filename) {
+  // Separate device+slash from tail
+  var result = splitDeviceRe.exec(filename),
+      device = (result[1] || '') + (result[2] || ''),
+      tail = result[3] || '';
+  // Split the tail into dir, basename and extension
+  var result2 = splitTailRe.exec(tail),
+      dir = result2[1],
+      basename = result2[2],
+      ext = result2[3];
+  return [device, dir, basename, ext];
+}
+
+function win32StatPath(path) {
+  var result = splitDeviceRe.exec(path),
+      device = result[1] || '',
+      isUnc = !!device && device[1] !== ':';
+  return {
+    device: device,
+    isUnc: isUnc,
+    isAbsolute: isUnc || !!result[2], // UNC paths are always absolute
+    tail: result[3]
+  };
+}
+
+function normalizeUNCRoot(device) {
+  return '\\\\' + device.replace(/^[\\\/]+/, '').replace(/[\\\/]+/g, '\\');
+}
+
+// path.resolve([from ...], to)
+win32.resolve = function() {
+  var resolvedDevice = '',
+      resolvedTail = '',
+      resolvedAbsolute = false;
+
+  for (var i = arguments.length - 1; i >= -1; i--) {
+    var path;
+    if (i >= 0) {
+      path = arguments[i];
+    } else if (!resolvedDevice) {
+      path = process.cwd();
+    } else {
+      // Windows has the concept of drive-specific current working
+      // directories. If we've resolved a drive letter but not yet an
+      // absolute path, get cwd for that drive. We're sure the device is not
+      // an unc path at this points, because unc paths are always absolute.
+      path = process.env['=' + resolvedDevice];
+      // Verify that a drive-local cwd was found and that it actually points
+      // to our drive. If not, default to the drive's root.
+      if (!path || path.substr(0, 3).toLowerCase() !==
+          resolvedDevice.toLowerCase() + '\\') {
+        path = resolvedDevice + '\\';
+      }
+    }
+
+    // Skip empty and invalid entries
+    if (!util.isString(path)) {
+      throw new TypeError('Arguments to path.resolve must be strings');
+    } else if (!path) {
+      continue;
+    }
+
+    var result = win32StatPath(path),
+        device = result.device,
+        isUnc = result.isUnc,
+        isAbsolute = result.isAbsolute,
+        tail = result.tail;
+
+    if (device &&
+        resolvedDevice &&
+        device.toLowerCase() !== resolvedDevice.toLowerCase()) {
+      // This path points to another device so it is not applicable
+      continue;
+    }
+
+    if (!resolvedDevice) {
+      resolvedDevice = device;
+    }
+    if (!resolvedAbsolute) {
+      resolvedTail = tail + '\\' + resolvedTail;
+      resolvedAbsolute = isAbsolute;
+    }
+
+    if (resolvedDevice && resolvedAbsolute) {
+      break;
     }
   }
 
-  return parts;
-}
+  // Convert slashes to backslashes when `resolvedDevice` points to an UNC
+  // root. Also squash multiple slashes into a single one where appropriate.
+  if (isUnc) {
+    resolvedDevice = normalizeUNCRoot(resolvedDevice);
+  }
+
+  // At this point the path should be resolved to a full absolute path,
+  // but handle relative paths to be safe (might happen when process.cwd()
+  // fails)
+
+  // Normalize the tail path
+  resolvedTail = normalizeArray(resolvedTail.split(/[\\\/]+/),
+                                !resolvedAbsolute).join('\\');
+
+  return (resolvedDevice + (resolvedAbsolute ? '\\' : '') + resolvedTail) ||
+         '.';
+};
 
 
-if (isWindows) {
-  // Regex to split a windows path into three parts: [*, device, slash,
-  // tail] windows-only
-  var splitDeviceRe =
-      /^([a-zA-Z]:|[\\\/]{2}[^\\\/]+[\\\/]+[^\\\/]+)?([\\\/])?([\s\S]*?)$/;
+win32.normalize = function(path) {
+  var result = win32StatPath(path),
+      device = result.device,
+      isUnc = result.isUnc,
+      isAbsolute = result.isAbsolute,
+      tail = result.tail,
+      trailingSlash = /[\\\/]$/.test(tail);
 
-  // Regex to split the tail part of the above into [*, dir, basename, ext]
-  var splitTailRe =
-      /^([\s\S]*?)((?:\.{1,2}|[^\\\/]+?|)(\.[^.\/\\]*|))(?:[\\\/]*)$/;
+  // Normalize the tail path
+  tail = normalizeArray(tail.split(/[\\\/]+/), !isAbsolute).join('\\');
 
-  // Function to split a filename into [root, dir, basename, ext]
-  // windows version
-  var splitPath = function(filename) {
-    // Separate device+slash from tail
-    var result = splitDeviceRe.exec(filename),
-        device = (result[1] || '') + (result[2] || ''),
-        tail = result[3] || '';
-    // Split the tail into dir, basename and extension
-    var result2 = splitTailRe.exec(tail),
-        dir = result2[1],
-        basename = result2[2],
-        ext = result2[3];
-    return [device, dir, basename, ext];
-  };
+  if (!tail && !isAbsolute) {
+    tail = '.';
+  }
+  if (tail && trailingSlash) {
+    tail += '\\';
+  }
 
-  var normalizeUNCRoot = function(device) {
-    return '\\\\' + device.replace(/^[\\\/]+/, '').replace(/[\\\/]+/g, '\\');
-  };
+  // Convert slashes to backslashes when `device` points to an UNC root.
+  // Also squash multiple slashes into a single one where appropriate.
+  if (isUnc) {
+    device = normalizeUNCRoot(device);
+  }
 
-  // path.resolve([from ...], to)
-  // windows version
-  exports.resolve = function() {
-    var resolvedDevice = '',
-        resolvedTail = '',
-        resolvedAbsolute = false;
+  return device + (isAbsolute ? '\\' : '') + tail;
+};
 
-    for (var i = arguments.length - 1; i >= -1; i--) {
-      var path;
-      if (i >= 0) {
-        path = arguments[i];
-      } else if (!resolvedDevice) {
-        path = process.cwd();
-      } else {
-        // Windows has the concept of drive-specific current working
-        // directories. If we've resolved a drive letter but not yet an
-        // absolute path, get cwd for that drive. We're sure the device is not
-        // an unc path at this points, because unc paths are always absolute.
-        path = process.env['=' + resolvedDevice];
-        // Verify that a drive-local cwd was found and that it actually points
-        // to our drive. If not, default to the drive's root.
-        if (!path || path.substr(0, 3).toLowerCase() !==
-            resolvedDevice.toLowerCase() + '\\') {
-          path = resolvedDevice + '\\';
-        }
-      }
 
-      // Skip empty and invalid entries
-      if (!util.isString(path)) {
-        throw new TypeError('Arguments to path.resolve must be strings');
-      } else if (!path) {
-        continue;
-      }
+win32.isAbsolute = function(path) {
+  return win32StatPath(path).isAbsolute;
+};
 
-      var result = splitDeviceRe.exec(path),
-          device = result[1] || '',
-          isUnc = device && device.charAt(1) !== ':',
-          isAbsolute = exports.isAbsolute(path),
-          tail = result[3];
-
-      if (device &&
-          resolvedDevice &&
-          device.toLowerCase() !== resolvedDevice.toLowerCase()) {
-        // This path points to another device so it is not applicable
-        continue;
-      }
-
-      if (!resolvedDevice) {
-        resolvedDevice = device;
-      }
-      if (!resolvedAbsolute) {
-        resolvedTail = tail + '\\' + resolvedTail;
-        resolvedAbsolute = isAbsolute;
-      }
-
-      if (resolvedDevice && resolvedAbsolute) {
-        break;
-      }
+win32.join = function() {
+  var paths = [];
+  for (var i = 0; i < arguments.length; i++) {
+    var arg = arguments[i];
+    if (!util.isString(arg)) {
+      throw new TypeError('Arguments to path.join must be strings');
     }
-
-    // Convert slashes to backslashes when `resolvedDevice` points to an UNC
-    // root. Also squash multiple slashes into a single one where appropriate.
-    if (isUnc) {
-      resolvedDevice = normalizeUNCRoot(resolvedDevice);
+    if (arg) {
+      paths.push(arg);
     }
+  }
 
-    // At this point the path should be resolved to a full absolute path,
-    // but handle relative paths to be safe (might happen when process.cwd()
-    // fails)
+  var joined = paths.join('\\');
 
-    // Normalize the tail path
+  // Make sure that the joined path doesn't start with two slashes, because
+  // normalize() will mistake it for an UNC path then.
+  //
+  // This step is skipped when it is very clear that the user actually
+  // intended to point at an UNC path. This is assumed when the first
+  // non-empty string arguments starts with exactly two slashes followed by
+  // at least one more non-slash character.
+  //
+  // Note that for normalize() to treat a path as an UNC path it needs to
+  // have at least 2 components, so we don't filter for that here.
+  // This means that the user can use join to construct UNC paths from
+  // a server name and a share name; for example:
+  //   path.join('//server', 'share') -> '\\\\server\\share\')
+  if (!/^[\\\/]{2}[^\\\/]/.test(paths[0])) {
+    joined = joined.replace(/^[\\\/]{2,}/, '\\');
+  }
 
-    function f(p) {
-      return !!p;
+  return win32.normalize(joined);
+};
+
+
+// path.relative(from, to)
+// it will solve the relative path from 'from' to 'to', for instance:
+// from = 'C:\\orandea\\test\\aaa'
+// to = 'C:\\orandea\\impl\\bbb'
+// The output of the function should be: '..\\..\\impl\\bbb'
+win32.relative = function(from, to) {
+  from = win32.resolve(from);
+  to = win32.resolve(to);
+
+  // windows is not case sensitive
+  var lowerFrom = from.toLowerCase();
+  var lowerTo = to.toLowerCase();
+
+  var toParts = trimArray(to.split('\\'));
+
+  var lowerFromParts = trimArray(lowerFrom.split('\\'));
+  var lowerToParts = trimArray(lowerTo.split('\\'));
+
+  var length = Math.min(lowerFromParts.length, lowerToParts.length);
+  var samePartsLength = length;
+  for (var i = 0; i < length; i++) {
+    if (lowerFromParts[i] !== lowerToParts[i]) {
+      samePartsLength = i;
+      break;
     }
+  }
 
-    resolvedTail = normalizeArray(resolvedTail.split(/[\\\/]+/).filter(f),
-                                  !resolvedAbsolute).join('\\');
+  if (samePartsLength == 0) {
+    return to;
+  }
 
-    return (resolvedDevice + (resolvedAbsolute ? '\\' : '') + resolvedTail) ||
-           '.';
-  };
+  var outputParts = [];
+  for (var i = samePartsLength; i < lowerFromParts.length; i++) {
+    outputParts.push('..');
+  }
 
-  // windows version
-  exports.normalize = function(path) {
-    var result = splitDeviceRe.exec(path),
-        device = result[1] || '',
-        isUnc = device && device.charAt(1) !== ':',
-        isAbsolute = exports.isAbsolute(path),
-        tail = result[3],
-        trailingSlash = /[\\\/]$/.test(tail);
+  outputParts = outputParts.concat(toParts.slice(samePartsLength));
 
-    // If device is a drive letter, we'll normalize to lower case.
-    if (device && device.charAt(1) === ':') {
-      device = device[0].toLowerCase() + device.substr(1);
-    }
-
-    // Normalize the tail path
-    tail = normalizeArray(tail.split(/[\\\/]+/).filter(function(p) {
-      return !!p;
-    }), !isAbsolute).join('\\');
-
-    if (!tail && !isAbsolute) {
-      tail = '.';
-    }
-    if (tail && trailingSlash) {
-      tail += '\\';
-    }
-
-    // Convert slashes to backslashes when `device` points to an UNC root.
-    // Also squash multiple slashes into a single one where appropriate.
-    if (isUnc) {
-      device = normalizeUNCRoot(device);
-    }
-
-    return device + (isAbsolute ? '\\' : '') + tail;
-  };
-
-  // windows version
-  exports.isAbsolute = function(path) {
-    var result = splitDeviceRe.exec(path),
-        device = result[1] || '',
-        isUnc = !!device && device.charAt(1) !== ':';
-    // UNC paths are always absolute
-    return !!result[2] || isUnc;
-  };
-
-  // windows version
-  exports.join = function() {
-    function f(p) {
-      if (!util.isString(p)) {
-        throw new TypeError('Arguments to path.join must be strings');
-      }
-      return p;
-    }
-
-    var paths = Array.prototype.filter.call(arguments, f);
-    var joined = paths.join('\\');
-
-    // Make sure that the joined path doesn't start with two slashes, because
-    // normalize() will mistake it for an UNC path then.
-    //
-    // This step is skipped when it is very clear that the user actually
-    // intended to point at an UNC path. This is assumed when the first
-    // non-empty string arguments starts with exactly two slashes followed by
-    // at least one more non-slash character.
-    //
-    // Note that for normalize() to treat a path as an UNC path it needs to
-    // have at least 2 components, so we don't filter for that here.
-    // This means that the user can use join to construct UNC paths from
-    // a server name and a share name; for example:
-    //   path.join('//server', 'share') -> '\\\\server\\share\')
-    if (!/^[\\\/]{2}[^\\\/]/.test(paths[0])) {
-      joined = joined.replace(/^[\\\/]{2,}/, '\\');
-    }
-
-    return exports.normalize(joined);
-  };
-
-  // path.relative(from, to)
-  // it will solve the relative path from 'from' to 'to', for instance:
-  // from = 'C:\\orandea\\test\\aaa'
-  // to = 'C:\\orandea\\impl\\bbb'
-  // The output of the function should be: '..\\..\\impl\\bbb'
-  // windows version
-  exports.relative = function(from, to) {
-    from = exports.resolve(from);
-    to = exports.resolve(to);
-
-    // windows is not case sensitive
-    var lowerFrom = from.toLowerCase();
-    var lowerTo = to.toLowerCase();
-
-    function trim(arr) {
-      var start = 0;
-      for (; start < arr.length; start++) {
-        if (arr[start] !== '') break;
-      }
-
-      var end = arr.length - 1;
-      for (; end >= 0; end--) {
-        if (arr[end] !== '') break;
-      }
-
-      if (start > end) return [];
-      return arr.slice(start, end + 1);
-    }
-
-    var toParts = trim(to.split('\\'));
-
-    var lowerFromParts = trim(lowerFrom.split('\\'));
-    var lowerToParts = trim(lowerTo.split('\\'));
-
-    var length = Math.min(lowerFromParts.length, lowerToParts.length);
-    var samePartsLength = length;
-    for (var i = 0; i < length; i++) {
-      if (lowerFromParts[i] !== lowerToParts[i]) {
-        samePartsLength = i;
-        break;
-      }
-    }
-
-    if (samePartsLength == 0) {
-      return to;
-    }
-
-    var outputParts = [];
-    for (var i = samePartsLength; i < lowerFromParts.length; i++) {
-      outputParts.push('..');
-    }
-
-    outputParts = outputParts.concat(toParts.slice(samePartsLength));
-
-    return outputParts.join('\\');
-  };
-
-  exports.sep = '\\';
-  exports.delimiter = ';';
-
-} else /* posix */ {
-
-  // Split a filename into [root, dir, basename, ext], unix version
-  // 'root' is just a slash, or nothing.
-  var splitPathRe =
-      /^(\/?|)([\s\S]*?)((?:\.{1,2}|[^\/]+?|)(\.[^.\/]*|))(?:[\/]*)$/;
-  var splitPath = function(filename) {
-    return splitPathRe.exec(filename).slice(1);
-  };
-
-  // path.resolve([from ...], to)
-  // posix version
-  exports.resolve = function() {
-    var resolvedPath = '',
-        resolvedAbsolute = false;
-
-    for (var i = arguments.length - 1; i >= -1 && !resolvedAbsolute; i--) {
-      var path = (i >= 0) ? arguments[i] : process.cwd();
-
-      // Skip empty and invalid entries
-      if (!util.isString(path)) {
-        throw new TypeError('Arguments to path.resolve must be strings');
-      } else if (!path) {
-        continue;
-      }
-
-      resolvedPath = path + '/' + resolvedPath;
-      resolvedAbsolute = path.charAt(0) === '/';
-    }
-
-    // At this point the path should be resolved to a full absolute path, but
-    // handle relative paths to be safe (might happen when process.cwd() fails)
-
-    // Normalize the path
-    resolvedPath = normalizeArray(resolvedPath.split('/').filter(function(p) {
-      return !!p;
-    }), !resolvedAbsolute).join('/');
-
-    return ((resolvedAbsolute ? '/' : '') + resolvedPath) || '.';
-  };
-
-  // path.normalize(path)
-  // posix version
-  exports.normalize = function(path) {
-    var isAbsolute = exports.isAbsolute(path),
-        trailingSlash = path[path.length - 1] === '/',
-        segments = path.split('/'),
-        nonEmptySegments = [];
-
-    // Normalize the path
-    for (var i = 0; i < segments.length; i++) {
-      if (segments[i]) {
-        nonEmptySegments.push(segments[i]);
-      }
-    }
-    path = normalizeArray(nonEmptySegments, !isAbsolute).join('/');
-
-    if (!path && !isAbsolute) {
-      path = '.';
-    }
-    if (path && trailingSlash) {
-      path += '/';
-    }
-
-    return (isAbsolute ? '/' : '') + path;
-  };
-
-  // posix version
-  exports.isAbsolute = function(path) {
-    return path.charAt(0) === '/';
-  };
-
-  // posix version
-  exports.join = function() {
-    var path = '';
-    for (var i = 0; i < arguments.length; i++) {
-      var segment = arguments[i];
-      if (!util.isString(segment)) {
-        throw new TypeError('Arguments to path.join must be strings');
-      }
-      if (segment) {
-        if (!path) {
-          path += segment;
-        } else {
-          path += '/' + segment;
-        }
-      }
-    }
-    return exports.normalize(path);
-  };
+  return outputParts.join('\\');
+};
 
 
-  // path.relative(from, to)
-  // posix version
-  exports.relative = function(from, to) {
-    from = exports.resolve(from).substr(1);
-    to = exports.resolve(to).substr(1);
+win32._makeLong = function(path) {
+  // Note: this will *probably* throw somewhere.
+  if (!util.isString(path))
+    return path;
 
-    function trim(arr) {
-      var start = 0;
-      for (; start < arr.length; start++) {
-        if (arr[start] !== '') break;
-      }
+  if (!path) {
+    return '';
+  }
 
-      var end = arr.length - 1;
-      for (; end >= 0; end--) {
-        if (arr[end] !== '') break;
-      }
+  var resolvedPath = win32.resolve(path);
 
-      if (start > end) return [];
-      return arr.slice(start, end + 1);
-    }
+  if (/^[a-zA-Z]\:\\/.test(resolvedPath)) {
+    // path is local filesystem path, which needs to be converted
+    // to long UNC path.
+    return '\\\\?\\' + resolvedPath;
+  } else if (/^\\\\[^?.]/.test(resolvedPath)) {
+    // path is network UNC path, which needs to be converted
+    // to long UNC path.
+    return '\\\\?\\UNC\\' + resolvedPath.substring(2);
+  }
 
-    var fromParts = trim(from.split('/'));
-    var toParts = trim(to.split('/'));
+  return path;
+};
 
-    var length = Math.min(fromParts.length, toParts.length);
-    var samePartsLength = length;
-    for (var i = 0; i < length; i++) {
-      if (fromParts[i] !== toParts[i]) {
-        samePartsLength = i;
-        break;
-      }
-    }
 
-    var outputParts = [];
-    for (var i = samePartsLength; i < fromParts.length; i++) {
-      outputParts.push('..');
-    }
-
-    outputParts = outputParts.concat(toParts.slice(samePartsLength));
-
-    return outputParts.join('/');
-  };
-
-  exports.sep = '/';
-  exports.delimiter = ':';
-}
-
-exports.dirname = function(path) {
-  var result = splitPath(path),
+win32.dirname = function(path) {
+  var result = win32SplitPath(path),
       root = result[0],
       dir = result[1];
 
@@ -465,8 +348,8 @@ exports.dirname = function(path) {
 };
 
 
-exports.basename = function(path, ext) {
-  var f = splitPath(path)[2];
+win32.basename = function(path, ext) {
+  var f = win32SplitPath(path)[2];
   // TODO: make this comparison case-insensitive on windows?
   if (ext && f.substr(-1 * ext.length) === ext) {
     f = f.substr(0, f.length - ext.length);
@@ -475,48 +358,271 @@ exports.basename = function(path, ext) {
 };
 
 
-exports.extname = function(path) {
-  return splitPath(path)[3];
+win32.extname = function(path) {
+  return win32SplitPath(path)[3];
 };
 
 
-exports.exists = util.deprecate(function(path, callback) {
-  require('fs').exists(path, callback);
-}, 'path.exists is now called `fs.exists`.');
+win32.format = function(pathObject) {
+  if (!util.isObject(pathObject)) {
+    throw new TypeError(
+        "Parameter 'pathObject' must be an object, not " + typeof pathObject
+    );
+  }
+
+  var root = pathObject.root || '';
+
+  if (!util.isString(root)) {
+    throw new TypeError(
+        "'pathObject.root' must be a string or undefined, not " +
+        typeof pathObject.root
+    );
+  }
+
+  var dir = pathObject.dir;
+  var base = pathObject.base || '';
+  if (!dir) {
+    return base;
+  }
+  if (dir[dir.length - 1] === win32.sep) {
+    return dir + base;
+  }
+  return dir + win32.sep + base;
+};
 
 
-exports.existsSync = util.deprecate(function(path) {
-  return require('fs').existsSync(path);
-}, 'path.existsSync is now called `fs.existsSync`.');
-
-
-if (isWindows) {
-  exports._makeLong = function(path) {
-    // Note: this will *probably* throw somewhere.
-    if (!util.isString(path))
-      return path;
-
-    if (!path) {
-      return '';
-    }
-
-    var resolvedPath = exports.resolve(path);
-
-    if (/^[a-zA-Z]\:\\/.test(resolvedPath)) {
-      // path is local filesystem path, which needs to be converted
-      // to long UNC path.
-      return '\\\\?\\' + resolvedPath;
-    } else if (/^\\\\[^?.]/.test(resolvedPath)) {
-      // path is network UNC path, which needs to be converted
-      // to long UNC path.
-      return '\\\\?\\UNC\\' + resolvedPath.substring(2);
-    }
-
-    return path;
+win32.parse = function(pathString) {
+  if (!util.isString(pathString)) {
+    throw new TypeError(
+        "Parameter 'pathString' must be a string, not " + typeof pathString
+    );
+  }
+  var allParts = win32SplitPath(pathString);
+  if (!allParts || allParts.length !== 4) {
+    throw new TypeError("Invalid path '" + pathString + "'");
+  }
+  return {
+    root: allParts[0],
+    dir: allParts[0] + allParts[1].slice(0, -1),
+    base: allParts[2],
+    ext: allParts[3],
+    name: allParts[2].slice(0, allParts[2].length - allParts[3].length)
   };
-} else {
-  exports._makeLong = function(path) {
-    return path;
-  };
+};
+
+
+win32.sep = '\\';
+win32.delimiter = ';';
+
+
+// Split a filename into [root, dir, basename, ext], unix version
+// 'root' is just a slash, or nothing.
+var splitPathRe =
+    /^(\/?|)([\s\S]*?)((?:\.{1,2}|[^\/]+?|)(\.[^.\/]*|))(?:[\/]*)$/;
+var posix = {};
+
+
+function posixSplitPath(filename) {
+  return splitPathRe.exec(filename).slice(1);
 }
-}());
+
+
+// path.resolve([from ...], to)
+// posix version
+posix.resolve = function() {
+  var resolvedPath = '',
+      resolvedAbsolute = false;
+
+  for (var i = arguments.length - 1; i >= -1 && !resolvedAbsolute; i--) {
+    var path = (i >= 0) ? arguments[i] : process.cwd();
+
+    // Skip empty and invalid entries
+    if (!util.isString(path)) {
+      throw new TypeError('Arguments to path.resolve must be strings');
+    } else if (!path) {
+      continue;
+    }
+
+    resolvedPath = path + '/' + resolvedPath;
+    resolvedAbsolute = path[0] === '/';
+  }
+
+  // At this point the path should be resolved to a full absolute path, but
+  // handle relative paths to be safe (might happen when process.cwd() fails)
+
+  // Normalize the path
+  resolvedPath = normalizeArray(resolvedPath.split('/'),
+                                !resolvedAbsolute).join('/');
+
+  return ((resolvedAbsolute ? '/' : '') + resolvedPath) || '.';
+};
+
+// path.normalize(path)
+// posix version
+posix.normalize = function(path) {
+  var isAbsolute = posix.isAbsolute(path),
+      trailingSlash = path && path[path.length - 1] === '/';
+
+  // Normalize the path
+  path = normalizeArray(path.split('/'), !isAbsolute).join('/');
+
+  if (!path && !isAbsolute) {
+    path = '.';
+  }
+  if (path && trailingSlash) {
+    path += '/';
+  }
+
+  return (isAbsolute ? '/' : '') + path;
+};
+
+// posix version
+posix.isAbsolute = function(path) {
+  return path.charAt(0) === '/';
+};
+
+// posix version
+posix.join = function() {
+  var path = '';
+  for (var i = 0; i < arguments.length; i++) {
+    var segment = arguments[i];
+    if (!util.isString(segment)) {
+      throw new TypeError('Arguments to path.join must be strings');
+    }
+    if (segment) {
+      if (!path) {
+        path += segment;
+      } else {
+        path += '/' + segment;
+      }
+    }
+  }
+  return posix.normalize(path);
+};
+
+
+// path.relative(from, to)
+// posix version
+posix.relative = function(from, to) {
+  from = posix.resolve(from).substr(1);
+  to = posix.resolve(to).substr(1);
+
+  var fromParts = trimArray(from.split('/'));
+  var toParts = trimArray(to.split('/'));
+
+  var length = Math.min(fromParts.length, toParts.length);
+  var samePartsLength = length;
+  for (var i = 0; i < length; i++) {
+    if (fromParts[i] !== toParts[i]) {
+      samePartsLength = i;
+      break;
+    }
+  }
+
+  var outputParts = [];
+  for (var i = samePartsLength; i < fromParts.length; i++) {
+    outputParts.push('..');
+  }
+
+  outputParts = outputParts.concat(toParts.slice(samePartsLength));
+
+  return outputParts.join('/');
+};
+
+
+posix._makeLong = function(path) {
+  return path;
+};
+
+
+posix.dirname = function(path) {
+  var result = posixSplitPath(path),
+      root = result[0],
+      dir = result[1];
+
+  if (!root && !dir) {
+    // No dirname whatsoever
+    return '.';
+  }
+
+  if (dir) {
+    // It has a dirname, strip trailing slash
+    dir = dir.substr(0, dir.length - 1);
+  }
+
+  return root + dir;
+};
+
+
+posix.basename = function(path, ext) {
+  var f = posixSplitPath(path)[2];
+  // TODO: make this comparison case-insensitive on windows?
+  if (ext && f.substr(-1 * ext.length) === ext) {
+    f = f.substr(0, f.length - ext.length);
+  }
+  return f;
+};
+
+
+posix.extname = function(path) {
+  return posixSplitPath(path)[3];
+};
+
+
+posix.format = function(pathObject) {
+  if (!util.isObject(pathObject)) {
+    throw new TypeError(
+        "Parameter 'pathObject' must be an object, not " + typeof pathObject
+    );
+  }
+
+  var root = pathObject.root || '';
+
+  if (!util.isString(root)) {
+    throw new TypeError(
+        "'pathObject.root' must be a string or undefined, not " +
+        typeof pathObject.root
+    );
+  }
+
+  var dir = pathObject.dir ? pathObject.dir + posix.sep : '';
+  var base = pathObject.base || '';
+  return dir + base;
+};
+
+
+posix.parse = function(pathString) {
+  if (!util.isString(pathString)) {
+    throw new TypeError(
+        "Parameter 'pathString' must be a string, not " + typeof pathString
+    );
+  }
+  var allParts = posixSplitPath(pathString);
+  if (!allParts || allParts.length !== 4) {
+    throw new TypeError("Invalid path '" + pathString + "'");
+  }
+  allParts[1] = allParts[1] || '';
+  allParts[2] = allParts[2] || '';
+  allParts[3] = allParts[3] || '';
+
+  return {
+    root: allParts[0],
+    dir: allParts[0] + allParts[1].slice(0, -1),
+    base: allParts[2],
+    ext: allParts[3],
+    name: allParts[2].slice(0, allParts[2].length - allParts[3].length)
+  };
+};
+
+
+posix.sep = '/';
+posix.delimiter = ':';
+
+
+if (isWindows)
+  module.exports = win32;
+else /* posix */
+  module.exports = posix;
+
+module.exports.posix = posix;
+module.exports.win32 = win32;


### PR DESCRIPTION
This PR resolves Issue #2  (and Issue #1 too).

I've upgraded `path.js` to the latest code from Node v0.12.7.  This code was copied straight from [`joyent/node/lib/path.js`](https://github.com/joyent/node/blob/master/lib/path.js).

I've added [`util`](https://www.npmjs.com/package/util) and [`process`](https://www.npmjs.com/package/process) as dependencies in the `package.json` file, since they are both used by the new code.

I've also gotten rid of the `var process = process || {}` line, in favor of the [`process`](https://www.npmjs.com/package/process) module. And I removed the [IIFE wrapper](https://en.wikipedia.org/wiki/Immediately-invoked_function_expression), since it's not needed for CommonJS modules.

I've verified that this code works with Browserify.  Not sure if any other CommonJS bundlers need to be supported or not.
