### PR TITLE
Remove --save option as it isn't required anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is an exact copy of the NodeJS ’path’ module published to the NPM regis
 ## Install
 
 ```sh
-$ npm install --save path
+$ npm install path
 ```
 
 ## License


### PR DESCRIPTION
"As of npm 5.0.0, installed modules are added as a dependency by default, so the --save option is no longer needed. The other save options still exist and are listed in the documentation for npm install."

https://stackoverflow.com/a/19578808/142358